### PR TITLE
feat: enhance rule logic to handle 'ref' calls without type annotations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslintConfigTypescript from '@yutengjing/eslint-config-typescript';
 import { defineConfig } from 'eslint/config';
+import globals from "globals";
 
 export default defineConfig([
     eslintConfigTypescript,
@@ -10,4 +11,14 @@ export default defineConfig([
             '@typescript-eslint/no-require-imports': 0,
         },
     },
+    {
+        files: [
+            "**/tests/**/*.test.js"
+        ],
+        languageOptions: {
+            globals: {
+                ...globals.mocha
+            }
+        }
+    }
 ]);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "bumpp": "^10.1.0",
         "eslint": "^9.23.0",
         "eslint-plugin-eslint-plugin": "^6.4.0",
+        "globals": "^16.0.0",
         "lint-staged": "^15.5.0",
         "prettier": "^3.5.3",
         "react": "^19.0.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -16,10 +16,13 @@
     },
     "dependencies": {
         "autocorrect-node": "^2.13.3",
-        "jsonc-parser": "^3.3.1"
+        "jsonc-parser": "^3.3.1",
+        "local-pkg": "^1.1.1"
     },
     "devDependencies": {
+        "@types/mocha": "^10.0.10",
         "mocha": "^11.1.0",
+        "sinon": "^20.0.0",
         "vue-eslint-parser": "^10.1.1"
     },
     "peerDependencies": {

--- a/packages/eslint-plugin/rules/no-declare-implicit-any-var.js
+++ b/packages/eslint-plugin/rules/no-declare-implicit-any-var.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const path = require('node:path');
+const localPkg = require('local-pkg');
+
+// https://github.com/antfu/eslint-config/blob/v4.13.0/src/factory.ts#L50
+const VuePackages = ['vue', 'nuxt', 'vitepress', '@slidev/cli'];
 
 const MESSAGE_ID_DEFAULT = 'default';
 
@@ -14,6 +18,8 @@ const create = (context) => {
         (ext === '.vue' &&
             /<script\s[^>]*?\blang=['"]ts['"][^>]*>/.test(context.sourceCode.getText()));
     if (!isTs) return {};
+
+    const enableVue = ext === '.vue' || VuePackages.some((i) => localPkg.isPackageExists(i));
 
     return {
         VariableDeclaration(node) {
@@ -32,7 +38,8 @@ const create = (context) => {
                         declarator.id.typeAnnotation == null &&
                         (init === null ||
                             (init.type === 'ArrayExpression' && init.elements.length === 0) ||
-                            (init.type === 'CallExpression' &&
+                            (enableVue &&
+                                init.type === 'CallExpression' &&
                                 init.callee.type === 'Identifier' &&
                                 init.callee.name === 'ref' &&
                                 init.typeArguments == null &&

--- a/packages/eslint-plugin/rules/no-declare-implicit-any-var.js
+++ b/packages/eslint-plugin/rules/no-declare-implicit-any-var.js
@@ -26,10 +26,19 @@ const create = (context) => {
                     const { init } = declarator;
                     // let a;
                     // let a = [];
+                    // const a = ref();
+                    // const a = ref([]);
                     if (
                         declarator.id.typeAnnotation == null &&
                         (init === null ||
-                            (init.type === 'ArrayExpression' && init.elements.length === 0))
+                            (init.type === 'ArrayExpression' && init.elements.length === 0) ||
+                            (init.type === 'CallExpression' &&
+                                init.callee.type === 'Identifier' &&
+                                init.callee.name === 'ref' &&
+                                init.typeArguments == null &&
+                                (init.arguments.length === 0 ||
+                                    (init.arguments[0].type === 'ArrayExpression' &&
+                                        init.arguments[0].elements.length === 0))))
                     ) {
                         context.report({
                             node: declarator,

--- a/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
+++ b/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 'use strict';
 
 const { ruleTester } = require('./utils');

--- a/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
+++ b/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { ruleTester } = require('./utils');
+const rule = require('../rules/no-declare-implicit-any-var');
+
+const [MESSAGE_ID_DEFAULT] = Object.keys(rule.meta.messages);
+
+ruleTester.run('no-declare-implicit-any-var', rule, {
+    valid: [
+        {
+            filename: 'test.ts',
+            code: 'const a = ref<string[]>([])',
+        },
+        {
+            filename: 'test.ts',
+            code: 'const a = ref<string>()',
+        },
+        {
+            filename: 'test.ts',
+            code: 'let a: string',
+        },
+        {
+            filename: 'test.ts',
+            code: 'let a: string[] = []',
+        },
+    ],
+    invalid: [
+        {
+            filename: 'test.ts',
+            code: 'let a',
+            errors: [
+                {
+                    messageId: MESSAGE_ID_DEFAULT,
+                },
+            ],
+        },
+        {
+            filename: 'test.ts',
+            code: 'let a = []',
+            errors: [
+                {
+                    messageId: MESSAGE_ID_DEFAULT,
+                },
+            ],
+        },
+        {
+            filename: 'test.ts',
+            code: 'const a = ref()',
+            errors: [
+                {
+                    messageId: MESSAGE_ID_DEFAULT,
+                },
+            ],
+        },
+        {
+            filename: 'test.ts',
+            code: 'const a = ref([])',
+            errors: [
+                {
+                    messageId: MESSAGE_ID_DEFAULT,
+                },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
+++ b/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
@@ -54,12 +54,10 @@ describe('no-declare-implicit-any-var mock with vue', () => {
     let stub;
 
     before(() => {
-        // 先 stub
         stub = sinon.stub(localPkg, 'isPackageExists').returns(true);
     });
 
     after(() => {
-        // 所有测试后恢复
         stub.restore();
     });
 

--- a/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
+++ b/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
@@ -13,6 +13,10 @@ ruleTester.run('no-declare-implicit-any-var', rule, {
         },
         {
             filename: 'test.ts',
+            code: 'const a = ref([] as string[])',
+        },
+        {
+            filename: 'test.ts',
             code: 'const a = ref<string>()',
         },
         {

--- a/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
+++ b/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
@@ -1,69 +1,130 @@
+/* eslint-env mocha */
+
 'use strict';
 
 const { ruleTester } = require('./utils');
 const rule = require('../rules/no-declare-implicit-any-var');
+const localPkg = require('local-pkg');
+const sinon = require('sinon');
 
 const [MESSAGE_ID_DEFAULT] = Object.keys(rule.meta.messages);
 
-ruleTester.run('no-declare-implicit-any-var', rule, {
-    valid: [
-        {
-            filename: 'test.ts',
-            code: 'const a = ref<string[]>([])',
-        },
-        {
-            filename: 'test.ts',
-            code: 'const a = ref([] as string[])',
-        },
-        {
-            filename: 'test.ts',
-            code: 'const a = ref<string>()',
-        },
-        {
-            filename: 'test.ts',
-            code: 'let a: string',
-        },
-        {
-            filename: 'test.ts',
-            code: 'let a: string[] = []',
-        },
-    ],
-    invalid: [
-        {
-            filename: 'test.ts',
-            code: 'let a',
-            errors: [
-                {
-                    messageId: MESSAGE_ID_DEFAULT,
-                },
-            ],
-        },
-        {
-            filename: 'test.ts',
-            code: 'let a = []',
-            errors: [
-                {
-                    messageId: MESSAGE_ID_DEFAULT,
-                },
-            ],
-        },
-        {
-            filename: 'test.ts',
-            code: 'const a = ref()',
-            errors: [
-                {
-                    messageId: MESSAGE_ID_DEFAULT,
-                },
-            ],
-        },
-        {
-            filename: 'test.ts',
-            code: 'const a = ref([])',
-            errors: [
-                {
-                    messageId: MESSAGE_ID_DEFAULT,
-                },
-            ],
-        },
-    ],
+describe('no-declare-implicit-any-var', () => {
+    ruleTester.run('no-declare-implicit-any-var', rule, {
+        valid: [
+            {
+                filename: 'test.ts',
+                code: 'let a: string',
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a: string[] = []',
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a = ref()',
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a = ref([])',
+            },
+        ],
+        invalid: [
+            {
+                filename: 'test.ts',
+                code: 'let a',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a = []',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+        ],
+    });
+});
+
+describe('no-declare-implicit-any-var mock with vue', () => {
+    let stub;
+
+    before(() => {
+        // 先 stub
+        stub = sinon.stub(localPkg, 'isPackageExists').returns(true);
+    });
+
+    after(() => {
+        // 所有测试后恢复
+        stub.restore();
+    });
+
+    ruleTester.run('no-declare-implicit-any-var', rule, {
+        valid: [
+            {
+                filename: 'test.ts',
+                code: 'const a = ref<string[]>([])',
+            },
+            {
+                filename: 'test.ts',
+                code: 'const a = ref([] as string[])',
+            },
+            {
+                filename: 'test.ts',
+                code: 'const a = ref<string>()',
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a: string',
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a: string[] = []',
+            },
+        ],
+        invalid: [
+            {
+                filename: 'test.ts',
+                code: 'let a',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+            {
+                filename: 'test.ts',
+                code: 'let a = []',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+            {
+                filename: 'test.ts',
+                code: 'const a = ref()',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+            {
+                filename: 'test.ts',
+                code: 'const a = ref([])',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+        ],
+    });
 });

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "@yutengjing/tsconfig-node-commonjs",
     "include": ["typings/**/*.d.ts", "**/*.js"],
     "compilerOptions": {
-        "skipLibCheck": false
+        "skipLibCheck": false,
+        "types": ["@types/mocha"]
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       eslint-plugin-eslint-plugin:
         specifier: ^6.4.0
         version: 6.4.0(eslint@9.23.0(jiti@2.4.2))
+      globals:
+        specifier: ^16.0.0
+        version: 16.0.0
       lint-staged:
         specifier: ^15.5.0
         version: 15.5.0
@@ -193,10 +196,19 @@ importers:
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
+      local-pkg:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       mocha:
         specifier: ^11.1.0
         version: 11.1.0
+      sinon:
+        specifier: ^20.0.0
+        version: 20.0.0
       vue-eslint-parser:
         specifier: ^10.1.1
         version: 10.1.1(eslint@9.23.0(jiti@2.4.2))
@@ -742,6 +754,15 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@13.0.5':
+    resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
+
+  '@sinonjs/samsam@8.0.2':
+    resolution: {integrity: sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==}
+
   '@swc/core-darwin-arm64@1.11.13':
     resolution: {integrity: sha512-loSERhLaQ9XDS+5Kdx8cLe2tM1G0HLit8MfehipAcsdctpo79zrRlkW34elOf3tQoVPKUItV0b/rTuhjj8NtHg==}
     engines: {node: '>=10'}
@@ -851,6 +872,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1495,6 +1519,10 @@ packages:
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
@@ -2416,9 +2444,17 @@ packages:
     resolution: {integrity: sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==}
     engines: {node: '>=18.0.0'}
 
+  local-pkg@1.1.1:
+    resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
+    engines: {node: '>=14'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2640,6 +2676,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mlly@1.7.4:
+    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+
   mocha@11.1.0:
     resolution: {integrity: sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2828,6 +2867,9 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   pkg-types@2.1.0:
     resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
 
@@ -2878,6 +2920,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quansync@0.2.10:
+    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3095,6 +3140,9 @@ packages:
     resolution: {integrity: sha512-NB3V4XyCOrWTIhjh85DyEoVlM3adHWwqQXKYHmuegy/108bJPP6YxuPGm4ZKBq1+GVKRbKJuzNY//09cMJYp+A==}
     hasBin: true
 
+  sinon@20.0.0:
+    resolution: {integrity: sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==}
+
   slashes@3.0.12:
     resolution: {integrity: sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==}
 
@@ -3265,6 +3313,14 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@4.38.0:
     resolution: {integrity: sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==}
     engines: {node: '>=16'}
@@ -3296,6 +3352,9 @@ packages:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3902,6 +3961,20 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@13.0.5':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      lodash.get: 4.4.2
+      type-detect: 4.1.0
+
   '@swc/core-darwin-arm64@1.11.13':
     optional: true
 
@@ -3985,6 +4058,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mocha@10.0.10': {}
 
   '@types/ms@2.1.0': {}
 
@@ -4646,6 +4721,8 @@ snapshots:
       dequal: 2.0.3
 
   diff@5.2.0: {}
+
+  diff@7.0.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -5850,9 +5927,17 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
 
+  local-pkg@1.1.1:
+    dependencies:
+      mlly: 1.7.4
+      pkg-types: 2.1.0
+      quansync: 0.2.10
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.get@4.4.2: {}
 
   lodash.merge@4.6.2: {}
 
@@ -6227,6 +6312,13 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mlly@1.7.4:
+    dependencies:
+      acorn: 8.14.1
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   mocha@11.1.0:
     dependencies:
       ansi-colors: 4.1.3
@@ -6435,6 +6527,12 @@ snapshots:
 
   pidtree@0.6.0: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.4
+      pathe: 2.0.3
+
   pkg-types@2.1.0:
     dependencies:
       confbox: 0.2.1
@@ -6482,6 +6580,8 @@ snapshots:
   proto-list@1.2.4: {}
 
   punycode@2.3.1: {}
+
+  quansync@0.2.10: {}
 
   queue-microtask@1.2.3: {}
 
@@ -6748,6 +6848,14 @@ snapshots:
 
   simple-git-hooks@2.12.1: {}
 
+  sinon@20.0.0:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 13.0.5
+      '@sinonjs/samsam': 8.0.2
+      diff: 7.0.0
+      supports-color: 7.2.0
+
   slashes@3.0.12: {}
 
   slice-ansi@5.0.0:
@@ -6936,6 +7044,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
+
   type-fest@4.38.0: {}
 
   typed-array-buffer@1.0.3:
@@ -6982,6 +7094,8 @@ snapshots:
       - supports-color
 
   typescript@5.8.2: {}
+
+  ufo@1.6.1: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
```ts
const a = ref()
   // ^ Ref<any>

const a = ref([])
   // ^ Ref<any[]>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced detection of variables declared without explicit type annotations, including those initialized via specific function calls, to better prevent implicit any types in Vue projects.

- **Tests**
  - Added comprehensive tests validating the rule's behavior in standard and Vue-simulated environments.

- **Chores**
  - Updated ESLint configuration to support Mocha globals in test files.
  - Added new development dependencies for improved testing and type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->