### PR TITLE
feat: enhance rule logic to handle 'shallowRef' calls without type annotations

### DIFF
--- a/packages/eslint-plugin/rules/no-declare-implicit-any-var.js
+++ b/packages/eslint-plugin/rules/no-declare-implicit-any-var.js
@@ -41,7 +41,7 @@ const create = (context) => {
                             (enableVue &&
                                 init.type === 'CallExpression' &&
                                 init.callee.type === 'Identifier' &&
-                                init.callee.name === 'ref' &&
+                                (init.callee.name === 'ref' || init.callee.name === 'shallowRef') &&
                                 init.typeArguments == null &&
                                 (init.arguments.length === 0 ||
                                     (init.arguments[0].type === 'ArrayExpression' &&

--- a/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
+++ b/packages/eslint-plugin/tests/no-declare-implicit-any-var.test.js
@@ -121,6 +121,24 @@ describe('no-declare-implicit-any-var mock with vue', () => {
                     },
                 ],
             },
+            {
+                filename: 'test.ts',
+                code: 'const a = shallowRef()',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
+            {
+                filename: 'test.ts',
+                code: 'const a = shallowRef([])',
+                errors: [
+                    {
+                        messageId: MESSAGE_ID_DEFAULT,
+                    },
+                ],
+            },
         ],
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the implicit-any variable rule to cover Vue shallowRef initializations, ensuring consistent linting with ref. Variables initialized via shallowRef without explicit types are now flagged appropriately.

* **Tests**
  * Added test cases to validate linting behavior for shallowRef initializations, improving coverage for Vue-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->